### PR TITLE
[FIX] epics: use uids / names for twiss, orbit survey consistently, BESSY II: conversion for survey (lm, ts)

### DIFF
--- a/scripts/bessyii/create_managers_input.py
+++ b/scripts/bessyii/create_managers_input.py
@@ -184,6 +184,10 @@ def build_liaison_manager_lut(
         LiaisonManagerInverseLookupElement(
             dev_id=DevicePropertyID(device_name="track", property="pos"),
             lat_ids=[LatticeElementPropertyID(element_name="track", property="pos")]
+        ),
+        LiaisonManagerInverseLookupElement(
+            dev_id=DevicePropertyID(device_name="survey", property="s"),
+            lat_ids=[LatticeElementPropertyID(element_name="survey", property="s")]
         )
     ]
     lut_fwd += [
@@ -194,6 +198,10 @@ def build_liaison_manager_lut(
         LiaisonManagerForwardLookupElement(
             lat_id=LatticeElementPropertyID(element_name="track", property="pos"),
             dev_ids=[DevicePropertyID(device_name="track", property="pos")]
+        ),
+        LiaisonManagerForwardLookupElement(
+            lat_id=LatticeElementPropertyID(element_name="survey", property="s"),
+            dev_ids=[DevicePropertyID(device_name="survey", property="s")]
         )
     ]
 
@@ -381,6 +389,12 @@ def build_translator_manager_lut(
         TranslatorLookupTableElement(
             ConversionID(LatticeElementPropertyID(element_name="track", property="pos"),
                          DevicePropertyID(device_name="track", property="pos"),
+                         ),
+            IdentityMapper()
+        ),
+        TranslatorLookupTableElement(
+            ConversionID(LatticeElementPropertyID(element_name="survey", property="s"),
+                         DevicePropertyID(device_name="survey", property="s"),
                          ),
             IdentityMapper()
         ),

--- a/src/dt4acc/custom_epics/ioc/pv_setup.py
+++ b/src/dt4acc/custom_epics/ioc/pv_setup.py
@@ -263,11 +263,11 @@ def initialize_survey_info_pvs(builder) -> Dict[ReadCommand, RecordWrapper]:
         ReadCommand(id="survey", property="s"): builder.WaveformIn(
             f"survey:s", initial_value=[0.0], EGU="m", length=config.n_elements
         ),
-        ReadCommand(id="survey", property="name"): builder.WaveformIn(
-            f"survey:name", initial_value=[""], length=config.n_elements
+        ReadCommand(id="survey", property="names"): builder.WaveformIn(
+            f"survey:names", initial_value=[""], length=config.n_elements
         ),
-        ReadCommand(id="survey", property="uid"): builder.WaveformIn(
-            f"survey:uid", initial_value=[""], length=config.n_elements
+        ReadCommand(id="survey", property="uids"): builder.WaveformIn(
+            f"survey:uids", initial_value=[""], length=config.n_elements
         ),
     }
 

--- a/src/dt4acc/custom_epics/ioc/view.py
+++ b/src/dt4acc/custom_epics/ioc/view.py
@@ -74,11 +74,11 @@ class View(ViewInterface):
         assert rec_s
         rec_s.set([datum.s for datum in single_reading.payload])
 
-        rec_name = self.process_variables.get(ReadCommand(id="survey", property="name"))
+        rec_name = self.process_variables.get(ReadCommand(id="survey", property="names"))
         assert rec_name
         rec_name.set([datum.name for datum in single_reading.payload])
 
-        rec_uid = self.process_variables.get(ReadCommand(id="survey", property="uid"))
+        rec_uid = self.process_variables.get(ReadCommand(id="survey", property="uids"))
         assert rec_uid
         rec_uid.set([datum.uid for datum in single_reading.payload])
 

--- a/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_liaison_manager_forward_lookup_table.yml
+++ b/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_liaison_manager_forward_lookup_table.yml
@@ -1,5 +1,5 @@
 # 
-# BESSY II Liaison manager forward table: 2026-06-11 18:39:20.638589
+# BESSY II Liaison manager forward table: 2026-06-16 15:23:03.761809
 # WARNING: automatically generated data
 #          please check when it is updated if you edit it by hand!
 lut:
@@ -1445,4 +1445,8 @@ lut:
   lat_id:
     element_name: track
     property: pos
+- dev_ids: [{device_name: survey, property: s}]
+  lat_id:
+    element_name: survey
+    property: s
 # EOF

--- a/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_liaison_manager_inverse_lookup_table.yml
+++ b/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_liaison_manager_inverse_lookup_table.yml
@@ -1,5 +1,5 @@
 # 
-# BESSY II Liaison manager inverse table: 2026-06-11 18:39:20.638589
+# BESSY II Liaison manager inverse table: 2026-06-16 15:23:03.761809
 # WARNING: automatically generated data
 #          please check when it is updated if you edit it by hand!
 lut:
@@ -6447,4 +6447,8 @@ lut:
     device_name: track
     property: pos
   lat_ids: [{element_name: track, property: pos}]
+- dev_id:
+    device_name: survey
+    property: s
+  lat_ids: [{element_name: survey, property: s}]
 # EOF

--- a/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_translation_service_lookup_table.yml
+++ b/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_translation_service_lookup_table.yml
@@ -1,5 +1,5 @@
 # 
-# BESSY II Translation service table: 2026-06-11 18:39:20.638589
+# BESSY II Translation service table: 2026-06-16 15:23:03.761809
 # WARNING: automatically generated data
 #          please check when it is updated if you edit it by hand!
 lut:
@@ -17935,5 +17935,13 @@ lut:
     lattice_property_id:
       element_name: track
       property: pos
+  conversion_info: {}
+- conversion_id:
+    device_property_id:
+      device_name: survey
+      property: s
+    lattice_property_id:
+      element_name: survey
+      property: s
   conversion_info: {}
 # EOF

--- a/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_yellow_pages_lookup_table.yml
+++ b/src/dt4acc/custom_facility/bessyii/resources/storage_ring/created/bessyii_yellow_pages_lookup_table.yml
@@ -1,5 +1,5 @@
 # 
-# BESSY II yellow pages: 2026-06-11 18:39:20.638589
+# BESSY II yellow pages: 2026-06-16 15:23:03.761809
 # WARNING: automatically generated data
 #          please check when it is updated if you edit it by hand!
 cavities: [CAVH1T8R, CAVH2T8R, CAVH3T8R, CAVH4T8R]

--- a/src/dt4acc/custom_facility/bessyii/run_bessyii_twin.py
+++ b/src/dt4acc/custom_facility/bessyii/run_bessyii_twin.py
@@ -38,7 +38,10 @@ from dt4acc.custom_epics.ioc.view import View
 from dt4acc.custom_facility.bessyii.liasion_translator_setup import load_managers
 
 logging.basicConfig(level=logging.WARNING)
-
+logging.getLogger("dt4acc_lib").setLevel(level=logging.WARNING)
+logging.getLogger("transitions").setLevel(level=logging.WARNING)
+logging.getLogger("transitions.core").setLevel(level=logging.WARNING)
+logging.getLogger("lat2db").setLevel(level=logging.WARNING)
 logger = logging.getLogger("dt4acc-bessyii")
 
 


### PR DESCRIPTION
Furthermore: reduced log level for used submodules for run twin