### PR TITLE
[TASK] Tango: split up of start of servers

### DIFF
--- a/src/dt4acc/custom_facility/maxiv/run_maxiv_twin.py
+++ b/src/dt4acc/custom_facility/maxiv/run_maxiv_twin.py
@@ -35,7 +35,7 @@ import os
 import sys
 from pathlib import Path
 
-from dt4acc.custom_tango.ioc import handle_lattice
+from dt4acc.custom_tango.ioc import handle_lattice, mexec_config, mexec_server_for_physics_engine
 
 # ---------------------------------------------------------------------------
 # Defaults
@@ -128,9 +128,9 @@ def main():
     enable_device_view_readback()
 
     handle_lattice.lattice_loader.set_lattice_file(args.lattice)
-    server_manager.LOAD_MANAGERS_FN = _maxiv_r1_load_managers
+    mexec_server_for_physics_engine.LOAD_MANAGERS_FN = _maxiv_r1_load_managers
     server_manager.HEARTBEAT_PERIOD = args.heartbeat_period
-    server_manager._MANAGER_PORT    = args.port
+    mexec_config._MANAGER_PORT = args.port
     server_manager.EXPECTED_VIEW    = args.view
 
     server_manager.main()

--- a/src/dt4acc/custom_facility/soleil/physics_engine/run_soleil_physics_engine.py
+++ b/src/dt4acc/custom_facility/soleil/physics_engine/run_soleil_physics_engine.py
@@ -1,0 +1,28 @@
+"""Physics engine as tango device
+
+Starts the mexec service and the tango device
+"""
+import os
+
+from dt4acc.custom_facility.soleil.run_soleil_twin import _soleil_load_managers
+from dt4acc.custom_facility.soleil.utils.command_line_interface import display_setup_from_args, parse_args
+from dt4acc.custom_tango.ioc import handle_lattice, mexec_server_for_physics_engine
+from dt4acc.custom_tango.ioc.mexec_server_for_physics_engine import _run_mexec_service
+
+
+def main():
+    args = parse_args()
+    print("Starting SOLEIL twin physics mexec engine")
+    display_setup_from_args(args)
+    os.environ["TANGO_HOST"] = args.tango_host
+
+    # Todo: need to improve handling configurations for load managers etc
+    mexec_server_for_physics_engine.LOAD_MANAGERS_FN = _soleil_load_managers
+
+    handle_lattice.lattice_loader.set_lattice_file(args.lattice)
+    print(handle_lattice.lattice_loader)
+    _run_mexec_service()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dt4acc/custom_facility/soleil/register_devices.py
+++ b/src/dt4acc/custom_facility/soleil/register_devices.py
@@ -1,0 +1,59 @@
+import json
+import pprint
+from typing import Sequence, Tuple
+
+from dt4acc.custom_facility.soleil.utils.command_line_interface import parse_args, display_setup_from_args, \
+    build_args_parser
+from dt4acc.custom_tango.ioc import handle_lattice
+from dt4acc.custom_tango.ioc.devices.tango_device_setup import register_all_devices, check_devices
+from dt4acc_lib.model.utils.tango_resource_locator import TangoResourceLocator
+
+
+def display_server_report(server_report):
+    if len(server_report.errors):
+        print("ERRORS :")
+        pprint.pprint(server_report.errors, compact=True)
+
+    if len(server_report.missing):
+        print("missing:")
+        pprint.pprint(server_report.errors, compact=True)
+
+    txt=f"""Server summary report
+     
+    numbers: errors {len(server_report.errors)} missing {len(server_report.missing)} found {len(server_report.present)}
+    """
+    print(txt)
+
+
+def trl_to_single_server_arguments(trl: Sequence[str]) -> Tuple[str, str]:
+    t = TangoResourceLocator.from_trl(trl)
+    return t.domain, t.family
+
+
+def export_present_devices(trls: Sequence[str], filename: str) -> None :
+    data = [trl_to_single_server_arguments(t) for t in trls]
+    with open(filename, "wt") as fp:
+        json.dump(data, fp, indent=4)
+
+
+def main():
+    arg_parser = build_args_parser()
+    arg_parser.add_argument("--register-devices", default=False)
+    arg_parser.add_argument("--export-present-devices", default="")
+    args = arg_parser.parse_args()
+    display_setup_from_args(args)
+    handle_lattice.lattice_loader.set_lattice_file(args.lattice)
+
+    if args.register_devices:
+        servers = register_all_devices()
+        print("Registered %d servers", len(servers))
+        pprint.pprint(servers, compact=True)
+    else:
+        server_report = check_devices()
+        display_server_report(server_report)
+        if args.export_present_devices:
+            export_present_devices(server_report.present, args.export_present_devices)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dt4acc/custom_facility/soleil/register_devices.py
+++ b/src/dt4acc/custom_facility/soleil/register_devices.py
@@ -1,12 +1,17 @@
 import json
 import pprint
-from typing import Sequence, Tuple
+from typing import Sequence
 
-from dt4acc.custom_facility.soleil.utils.command_line_interface import parse_args, display_setup_from_args, \
-    build_args_parser
+from dt4acc.custom_facility.soleil.utils.command_line_interface import (
+    display_setup_from_args,
+    build_args_parser,
+)
 from dt4acc.custom_tango.ioc import handle_lattice
-from dt4acc.custom_tango.ioc.devices.tango_device_setup import register_all_devices, check_devices
-from dt4acc_lib.model.utils.tango_resource_locator import TangoResourceLocator
+from dt4acc.custom_tango.ioc.devices.tango_device_setup import (
+    register_all_devices,
+    check_devices,
+    family_trl_to_single_server_arguments,
+)
 
 
 def display_server_report(server_report):
@@ -18,20 +23,15 @@ def display_server_report(server_report):
         print("missing:")
         pprint.pprint(server_report.errors, compact=True)
 
-    txt=f"""Server summary report
-     
+    txt = f"""Server summary report
+
     numbers: errors {len(server_report.errors)} missing {len(server_report.missing)} found {len(server_report.present)}
     """
     print(txt)
 
 
-def trl_to_single_server_arguments(trl: Sequence[str]) -> Tuple[str, str]:
-    t = TangoResourceLocator.from_trl(trl)
-    return t.domain, t.family
-
-
-def export_present_devices(trls: Sequence[str], filename: str) -> None :
-    data = [trl_to_single_server_arguments(t) for t in trls]
+def export_present_devices(trls: Sequence[str], filename: str) -> None:
+    data = [family_trl_to_single_server_arguments(t) for t in trls]
     with open(filename, "wt") as fp:
         json.dump(data, fp, indent=4)
 

--- a/src/dt4acc/custom_facility/soleil/run_soleil_twin.py
+++ b/src/dt4acc/custom_facility/soleil/run_soleil_twin.py
@@ -30,12 +30,15 @@ Environment variables (all optional, CLI args take precedence)
     DT4ACC_VIEW           Design or Device view (default: design)
 """
 
-import argparse
 import os
 import sys
 from pathlib import Path
 
-from dt4acc.custom_tango.ioc import handle_lattice
+
+
+from dt4acc.custom_facility.soleil.utils.command_line_interface import display_setup_from_args, parse_args
+from dt4acc.custom_tango.ioc import handle_lattice, mexec_config, mexec_server_for_physics_engine
+from dt4acc.custom_tango.ioc import server_manager
 
 # ---------------------------------------------------------------------------
 # Resolve paths — script lives at scripts/soleil/, src is two levels up
@@ -47,61 +50,6 @@ SRC_DIR     = ROOT_DIR / "src"
 
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
-
-# ---------------------------------------------------------------------------
-# SOLEIL defaults
-# ---------------------------------------------------------------------------
-
-DEFAULT_LATTICE_FILE = (
-    Path.home()
-    / "Documents"
-    / "dt4acc_config_data"
-    / "SOLEIL_II_V3635_STAB_SYM1_SB3_MULT7_4SX60_V001_Nomenclature.m"
-)
-
-# Calculation heartbeat: recalculates twiss+orbit+tune every N seconds
-# WITHOUT changing the lattice — zero noise, reflects current state
-DEFAULT_HEARTBEAT_PERIOD_S = 1.0
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Launch the SOLEIL digital twin TANGO server"
-    )
-    parser.add_argument(
-        "--lattice",
-        type=Path,
-        default=Path(os.environ.get("DT4ACC_LATTICE_FILE", DEFAULT_LATTICE_FILE)),
-        help=f"Path to the SOLEIL AT lattice .m file (default: {DEFAULT_LATTICE_FILE})",
-    )
-    parser.add_argument(
-        "--tango-host",
-        default=os.environ.get("DT4ACC_TANGO_HOST", "localhost:10000"),
-        help="Tango database host:port (default: localhost:10000)",
-    )
-    parser.add_argument(
-        "--heartbeat-period",
-        type=float,
-        default=DEFAULT_HEARTBEAT_PERIOD_S,
-        help=f"Recalculation period in seconds, 0 to disable (default: {DEFAULT_HEARTBEAT_PERIOD_S})",
-    )
-    parser.add_argument(
-        "--port",
-        type=int,
-        default=50200,
-        help="TCP port for the MexecService manager (default: 50200)",
-    )
-    parser.add_argument(
-        "--view",
-        type=str,
-        default=os.environ.get("DT4ACC_VIEW", "design"),
-        help="Design or Device view (default: design)",
-    )
-    return parser.parse_args()
 
 
 # ---------------------------------------------------------------------------
@@ -125,21 +73,15 @@ def main():
         print(f"ERROR: Lattice file not found: {args.lattice}", file=sys.stderr)
         sys.exit(1)
 
-    print("SOLEIL twin server starting")
-    print(f"  Lattice          : {args.lattice}")
-    print(f"  TANGO            : {args.tango_host}")
-    print(f"  Recalc period    : {args.heartbeat_period}s (no lattice changes)")
-    print(f"  MexecPort        : {args.port}")
-    print(f"  View             : {args.view}")
-
+    print("Starting SOLEIL Digital Twin (all servers)")
+    display_setup_from_args(args)
     os.environ["TANGO_HOST"] = args.tango_host
 
-    from dt4acc.custom_tango.ioc import server_manager
 
     handle_lattice.lattice_loader.set_lattice_file(args.lattice)
-    server_manager.LOAD_MANAGERS_FN  = _soleil_load_managers
+    mexec_server_for_physics_engine.LOAD_MANAGERS_FN = _soleil_load_managers
     server_manager.HEARTBEAT_PERIOD  = args.heartbeat_period
-    server_manager._MANAGER_PORT     = args.port
+    mexec_config._MANAGER_PORT = args.port
     server_manager.EXPECTED_VIEW     = args.view
 
     server_manager.main()

--- a/src/dt4acc/custom_facility/soleil/utils/command_line_interface.py
+++ b/src/dt4acc/custom_facility/soleil/utils/command_line_interface.py
@@ -1,0 +1,73 @@
+import argparse
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# SOLEIL defaults
+# ---------------------------------------------------------------------------
+DEFAULT_LATTICE_FILE = (
+    Path.home()
+    / "Documents"
+    / "dt4acc_config_data"
+    / "SOLEIL_II_V3635_STAB_SYM1_SB3_MULT7_4SX60_V001_Nomenclature.m"
+)
+
+# Calculation heartbeat: recalculates twiss+orbit+tune every N seconds
+# WITHOUT changing the lattice — zero noise, reflects current state
+
+DEFAULT_HEARTBEAT_PERIOD_S = 1.0
+
+# ---------------------------------------------------------------------------
+# CLI: standared arguments
+# ---------------------------------------------------------------------------
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Launch the SOLEIL digital twin TANGO server"
+    )
+    parser.add_argument(
+        "--lattice",
+        type=Path,
+        default=Path(os.environ.get("DT4ACC_LATTICE_FILE", DEFAULT_LATTICE_FILE)),
+        help=f"Path to the SOLEIL AT lattice .m file (default: {DEFAULT_LATTICE_FILE})",
+    )
+    parser.add_argument(
+        "--tango-host",
+        default=os.environ.get("DT4ACC_TANGO_HOST", "localhost:10000"),
+        help="Tango database host:port (default: localhost:10000)",
+    )
+    parser.add_argument(
+        "--heartbeat-period",
+        type=float,
+        default=DEFAULT_HEARTBEAT_PERIOD_S,
+        help=f"Recalculation period in seconds, 0 to disable (default: {DEFAULT_HEARTBEAT_PERIOD_S})",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=50200,
+        help="TCP port for the MexecService manager (default: 50200)",
+    )
+    parser.add_argument(
+        "--view",
+        type=str,
+        default=os.environ.get("DT4ACC_VIEW", "design"),
+        help="Design or Device view (default: design)",
+    )
+    return parser.parse_args()
+
+
+def standard_setup_from_environment():
+    """
+    Should be run at the very beginning of script or process
+    """
+    os.environ.setdefault("TANGO_HOST", "localhost:10000")
+
+
+def display_setup_from_args(args):
+    print("Arguments used")
+    print(f"  Lattice          : {args.lattice}")
+    print(f"  TANGO            : {args.tango_host}")
+    print(f"  Recalc period    : {args.heartbeat_period}s (no lattice changes)")
+    print(f"  MexecPort        : {args.port}")
+    print(f"  View             : {args.view}")
+

--- a/src/dt4acc/custom_facility/soleil/utils/command_line_interface.py
+++ b/src/dt4acc/custom_facility/soleil/utils/command_line_interface.py
@@ -20,7 +20,7 @@ DEFAULT_HEARTBEAT_PERIOD_S = 1.0
 # ---------------------------------------------------------------------------
 # CLI: standared arguments
 # ---------------------------------------------------------------------------
-def parse_args():
+def build_args_parser():
     parser = argparse.ArgumentParser(
         description="Launch the SOLEIL digital twin TANGO server"
     )
@@ -53,7 +53,11 @@ def parse_args():
         default=os.environ.get("DT4ACC_VIEW", "design"),
         help="Design or Device view (default: design)",
     )
-    return parser.parse_args()
+    return parser
+
+
+def parse_args():
+    return build_args_parser().parse_args()
 
 
 def standard_setup_from_environment():

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -3,6 +3,7 @@
 from tango import Database, DbDevInfo, DevFailed
 
 from dataclasses import dataclass, field
+from typing import Any
 from dt4acc.core.utils.logger import get_logger
 from dt4acc.config.data.querries import (
     get_unique_power_converters,
@@ -35,16 +36,44 @@ class DeviceCheckReport:
 class DeviceExpected:
     kind: str
     name: str
+    class_name: str
+    server_name: str
+    instance_name: str
+    properties: dict[str, list[str]] = field(default_factory=dict)
+
+    @property
+    def server_str(self) -> str:
+        return f"{self.server_name}/{self.instance_name}"
 
 
 @dataclass
 class DevicePlan:
     devices: list[DeviceExpected] = field(default_factory=list)
+    servers: set[tuple[str, str]] = field(default_factory=set)
 
 
-def _add_expected_device(plan: DevicePlan, kind: str, name: str) -> None:
-    if name:
-        plan.devices.append(DeviceExpected(kind=kind, name=name))
+def _add_expected_device(
+    plan: DevicePlan,
+    kind: str,
+    name: str,
+    class_name: str,
+    server_name: str,
+    instance_name: str,
+    properties: dict[str, list[str]] | None = None,
+) -> None:
+    if not name:
+        return
+    plan.devices.append(
+        DeviceExpected(
+            kind=kind,
+            name=name,
+            class_name=class_name,
+            server_name=server_name,
+            instance_name=instance_name,
+            properties=properties or {},
+        )
+    )
+    plan.servers.add((server_name, instance_name))
 
 
 def build_device_plan() -> DevicePlan:
@@ -57,7 +86,48 @@ def build_device_plan() -> DevicePlan:
     # Magnets
     for pc_name in get_unique_power_converters():
         for m in get_magnets_per_power_converters(pc_name):
-            _add_expected_device(plan, "magnet", m.get("name", ""))
+            magnet_name = m["name"]
+            magnet_uuid = m.get("uuid", "") or (m.get("uuids", [""])[0] if m.get("uuids") else "")
+            magnet_type = m.get("type", "")
+            magnet_subtype = m.get("subtype", "")
+
+            trl = TangoResourceLocator.from_trl(magnet_name)
+            server_name, instance_name = trl.domain, trl.family
+
+            if magnet_type == "Steerer":
+                class_name = _steerer_class(magnet_name, subtype=magnet_subtype)
+            else:
+                class_name = _TYPE_TO_CLASS.get(magnet_type, "MultipoleDevice")
+
+            _SUBTYPE_TO_LATTICE_PROP = {
+                "Quad": "B2",
+                "Sext": "B3",
+                "SkewSext": "B3",
+                "Oct": "B4",
+            }
+            if magnet_type == "QuadrupoleCorrector":
+                lattice_prop = "B2"
+            elif magnet_type == "SkewQuadrupoleCorrector":
+                lattice_prop = "A2"
+            else:
+                lattice_prop = _SUBTYPE_TO_LATTICE_PROP.get(magnet_subtype, "main_strength")
+
+            props: dict[str, list[str]] = {}
+            if magnet_uuid:
+                props["element_uuid"] = [magnet_uuid]
+            if pc_name:
+                props["power_supply"] = [pc_name]
+            props["lattice_property"] = [lattice_prop]
+
+            _add_expected_device(
+                plan,
+                "magnet",
+                magnet_name,
+                class_name,
+                server_name,
+                instance_name,
+                props,
+            )
 
     # Power converters
     from dt4acc.custom_tango.ioc.server_manager import EXPECTED_VIEW
@@ -67,19 +137,107 @@ def build_device_plan() -> DevicePlan:
             if pc_name in seen:
                 continue
             seen.add(pc_name)
-            _add_expected_device(plan, "power_converter", pc_name)
+
+            trl = TangoResourceLocator.from_trl(pc_name)
+            server_name, instance_name = trl.domain, trl.family
+            pc_magnet_names = [m["name"] for m in get_magnets_per_power_converters(pc_name)]
+
+            props: dict[str, list[str]] = {}
+            if pc_magnet_names:
+                props["magnets"] = pc_magnet_names
+
+            _add_expected_device(
+                plan,
+                "power_converter",
+                pc_name,
+                "PowerConverterDevice",
+                server_name,
+                instance_name,
+                props,
+            )
 
     # Cavities
     for pc_name in get_unique_power_converters_type_specified(["RFCavity"]):
         for m in get_magnets_per_power_converters(pc_name):
-            _add_expected_device(plan, "cavity", m.get("name", ""))
+            dev_name = m["name"]
+            dev_uuid = m.get("uuid", "")
+            dev_type = m.get("type", "")
+            class_name = _TYPE_TO_CLASS.get(dev_type, "MultipoleDevice")
+
+            trl = TangoResourceLocator.from_trl(dev_name)
+            server_name, instance_name = trl.domain, trl.family
+
+            props: dict[str, list[str]] = {}
+            if dev_uuid:
+                props["element_uuid"] = [dev_uuid]
+
+            _add_expected_device(
+                plan,
+                "cavity",
+                dev_name,
+                class_name,
+                server_name,
+                instance_name,
+                props,
+            )
 
     # Ring simulator
-    _add_expected_device(plan, "ring_simulator", RING_SIM_DEV)
+    trl = TangoResourceLocator.from_trl(RING_SIM_DEV)
+    _add_expected_device(
+        plan,
+        "ring_simulator",
+        RING_SIM_DEV,
+        "RingSimulatorDevice",
+        trl.domain,
+        trl.family,
+        {},
+    )
 
     # BPMs
+    bpm_index_map: dict = {}
+    try:
+        import at as _at  # noqa: F401
+        from dt4acc.custom_tango.ioc.handle_lattice import lattice_loader
+
+        lattice = lattice_loader.load()
+        for i, elem in enumerate(lattice):
+            if getattr(elem, "FamName", None) in ("BPM", "FBPM"):
+                uuid = getattr(elem, "UUID", None)
+                if uuid:
+                    bpm_index_map[uuid] = i
+        logger.info("BPM plan: resolved %d BPM orbit indices from lattice", len(bpm_index_map))
+    except Exception as e:
+        logger.warning("BPM plan: could not build orbit index map: %s", e)
+
     for bpm in get_bpms():
-        _add_expected_device(plan, "bpm", bpm.get("name", ""))
+        bpm_name = bpm.get("name")
+        bpm_uuid = bpm.get("uuid")
+        bpm_spos = float(bpm.get("s_pos", 0.0))
+        if not bpm_name:
+            continue
+
+        orbit_index = bpm_index_map.get(bpm_uuid, -1)
+        try:
+            trl = TangoResourceLocator.from_trl(bpm_name)
+            server_name, instance_name = trl.domain, trl.family
+
+            props = {
+                "lattice_id": [bpm_uuid] if bpm_uuid else [],
+                "s_pos": [str(bpm_spos)],
+                "orbit_index": [str(orbit_index)],
+            }
+
+            _add_expected_device(
+                plan,
+                "bpm",
+                bpm_name,
+                "BPMDevice",
+                server_name,
+                instance_name,
+                props,
+            )
+        except Exception as e:
+            logger.warning("BPM plan: skipping %s: %s", bpm_name, e)
 
     return plan
 
@@ -88,7 +246,7 @@ def check_devices() -> DeviceCheckReport:
     """
     Read-only validation entry point.
 
-    This first version only checks whether Tango can resolve each expected
+    This version only checks whether Tango can resolve each expected
     device with get_device_info(). It does not validate properties yet.
     """
     db = Database()
@@ -106,8 +264,6 @@ def check_devices() -> DeviceCheckReport:
             report.errors.append(f"{expected.kind}: {expected.name}: {e}")
 
     return report
-
-
 # Map JSON "type" field → Tango device class name
 _TYPE_TO_CLASS = {
     "Quadrupole":              "MultipoleDevice",
@@ -418,9 +574,11 @@ def register_all_devices():
         list[(server_name, instance_name)] : all unique device servers to start.
     """
     db = Database()
-    unique_servers: set[tuple[str, str]] = set()
+    plan = build_device_plan()
+    unique_servers: set[tuple[str, str]] = set(plan.servers)
 
     logger.info("📝 Registering ALL devices into Tango DB...")
+    logger.info("🧭 Planned %d devices across %d servers", len(plan.devices), len(plan.servers))
 
     _register_magnets(db, unique_servers)
     _register_power_converters(db, unique_servers)

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -23,6 +23,7 @@ from dt4acc_lib.model.utils.tango_resource_locator import TangoResourceLocator
 logger = get_logger()
 
 
+
 @dataclass
 class DeviceCheckReport:
     present: list[str] = field(default_factory=list)
@@ -30,19 +31,80 @@ class DeviceCheckReport:
     errors: list[str] = field(default_factory=list)
 
 
+@dataclass
+class DeviceExpected:
+    kind: str
+    name: str
+
+
+@dataclass
+class DevicePlan:
+    devices: list[DeviceExpected] = field(default_factory=list)
+
+
+def _add_expected_device(plan: DevicePlan, kind: str, name: str) -> None:
+    if name:
+        plan.devices.append(DeviceExpected(kind=kind, name=name))
+
+
+def build_device_plan() -> DevicePlan:
+    """
+    Build the expected device inventory from the same source data used by
+    registration.
+    """
+    plan = DevicePlan()
+
+    # Magnets
+    for pc_name in get_unique_power_converters():
+        for m in get_magnets_per_power_converters(pc_name):
+            _add_expected_device(plan, "magnet", m.get("name", ""))
+
+    # Power converters
+    from dt4acc.custom_tango.ioc.server_manager import EXPECTED_VIEW
+    if EXPECTED_VIEW == "device":
+        seen = set()
+        for pc_name in get_unique_power_converters():
+            if pc_name in seen:
+                continue
+            seen.add(pc_name)
+            _add_expected_device(plan, "power_converter", pc_name)
+
+    # Cavities
+    for pc_name in get_unique_power_converters_type_specified(["RFCavity"]):
+        for m in get_magnets_per_power_converters(pc_name):
+            _add_expected_device(plan, "cavity", m.get("name", ""))
+
+    # Ring simulator
+    _add_expected_device(plan, "ring_simulator", RING_SIM_DEV)
+
+    # BPMs
+    for bpm in get_bpms():
+        _add_expected_device(plan, "bpm", bpm.get("name", ""))
+
+    return plan
+
+
 def check_devices() -> DeviceCheckReport:
     """
     Read-only validation entry point.
 
-    Patch 2:
-    - no registration
-    - no behaviour change to existing registration path
-    - foundation for check vs ensure mode
+    This first version only checks whether Tango can resolve each expected
+    device with get_device_info(). It does not validate properties yet.
     """
     db = Database()
     report = DeviceCheckReport()
+    plan = build_device_plan()
 
-    # TODO: implement device inventory checks in patch 3
+    for expected in plan.devices:
+        try:
+            info = db.get_device_info(expected.name)
+            if info is not None:
+                report.present.append(f"{expected.kind}: {expected.name}")
+            else:
+                report.missing.append(f"{expected.kind}: {expected.name}")
+        except Exception as e:
+            report.errors.append(f"{expected.kind}: {expected.name}: {e}")
+
     return report
 
 

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -3,7 +3,7 @@
 from tango import Database, DbDevInfo, DevFailed
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Sequence, Tuple
 from dt4acc.core.utils.logger import get_logger
 from dt4acc.config.data.querries import (
     get_unique_power_converters,
@@ -609,7 +609,17 @@ def ensure_devices(register_missing: bool = False):
     if register_missing:
         return register_all_devices()
 
-    return check_devices()
+    tmp = [family_trl_to_single_server_arguments(trl) for trl in check_devices().present]
+    single_server_args = list(set(tmp))
+    return single_server_args
+
+
+def family_trl_to_single_server_arguments(family_and_trl: Sequence[str]) -> Tuple[str, str]:
+    """Todo: need to rework DeviceCheckReport to contain proper isolated TRL's
+    """
+    family, trl = family_and_trl.split(":")
+    t = TangoResourceLocator.from_trl(trl.strip())
+    return t.domain, t.family
 
 
 def get_all_device_classes():

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -1,6 +1,8 @@
 # tango_device_setup.py
 
 from tango import Database, DbDevInfo, DevFailed
+
+from dataclasses import dataclass, field
 from dt4acc.core.utils.logger import get_logger
 from dt4acc.config.data.querries import (
     get_unique_power_converters,
@@ -19,6 +21,30 @@ from dt4acc.custom_tango.ioc.devices.bpm_device import BPMDevice
 from dt4acc_lib.model.utils.tango_resource_locator import TangoResourceLocator
 
 logger = get_logger()
+
+
+@dataclass
+class DeviceCheckReport:
+    present: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def check_devices() -> DeviceCheckReport:
+    """
+    Read-only validation entry point.
+
+    Patch 2:
+    - no registration
+    - no behaviour change to existing registration path
+    - foundation for check vs ensure mode
+    """
+    db = Database()
+    report = DeviceCheckReport()
+
+    # TODO: implement device inventory checks in patch 3
+    return report
+
 
 # Map JSON "type" field → Tango device class name
 _TYPE_TO_CLASS = {

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -624,14 +624,3 @@ def get_all_device_classes():
         RingSimulatorDevice,
         BPMDevice,
     ]
-
-
-def main():
-    import pprint
-
-    servers = register_all_devices()
-    print("Registered %d servers", len(servers))
-    pprint.pprint(servers, compact=True)
-
-if __name__ == "__main__":
-    main()

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -376,6 +376,23 @@ def register_all_devices():
 
     return sorted(unique_servers)
 
+
+def ensure_devices(register_missing: bool = False):
+    """
+    Unified public entrypoint.
+
+    register_missing=False:
+        run read-only checks
+
+    register_missing=True:
+        register missing devices (current behaviour)
+    """
+    if register_missing:
+        return register_all_devices()
+
+    return check_devices()
+
+
 def get_all_device_classes():
     """Return all device classes used by the servers."""
     return [

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -80,25 +80,9 @@ def _register_dservers(db: Database, servers: set[tuple[str, str]]):
                 logger.error(f"❌ Failed to register DServer {dserver_name}: {e}")
 
 
-def register_all_devices():
-    """
-    Register ALL Soleil devices in the Tango DB.
 
-    - Device *names* are the Soleil-style names (AN10-AR/EM/SCF.11, ...).
-    - For each device name:
-        domain  -> server_name
-        family  -> instance_name
-        server  -> f"{server_name}/{instance_name}"
-    - Also registers DServer devices for each (server_name, instance_name).
-
-    Returns:
-        list[(server_name, instance_name)] : all unique device servers to start.
-    """
-    db = Database()
-    unique_servers: set[tuple[str, str]] = set()
-
-    logger.info("📝 Registering ALL devices into Tango DB...")
-
+def _register_magnets(db: Database, unique_servers: set[tuple[str, str]]):
+    """Register magnet devices and properties."""
     # ------------------------------------------------------------
     # 1) Magnets — registered by Tango name (magnet TRL)
     #    UUID/uuids stored as DB property for AT element lookup.
@@ -163,6 +147,8 @@ def register_all_devices():
             except Exception as e:
                 logger.error("❌ Failed to register magnet %s: %s", magnet_name, e)
 
+def _register_power_converters(db: Database, unique_servers: set[tuple[str, str]]):
+    """Register power converter devices and properties."""
     # ------------------------------------------------------------
     # 2) Power converters — device view only.
     #    In design view the magnet device is the control source — no PC devices.
@@ -202,7 +188,8 @@ def register_all_devices():
             except Exception as e:
                 logger.warning("Skipping PC %s (not a valid TRL?): %s", pc_name, e)
 
-    # ------------------------------------------------------------
+def _register_cavities(db: Database, unique_servers: set[tuple[str, str]]):
+    """Register cavity devices."""
     # 2) Cavities — registered as typed devices
     # ------------------------------------------------------------
     for pc_name in get_unique_power_converters_type_specified(["RFCavity"]):
@@ -236,7 +223,8 @@ def register_all_devices():
             except Exception as e:
                 logger.error("❌ Failed to register %s %s: %s", dev_type, dev_name, e)
 
-    # ------------------------------------------------------------
+def _register_ring_simulator(db: Database, unique_servers: set[tuple[str, str]]):
+    """Register the RingSimulatorDevice."""
     # 3) Single RingSimulatorDevice — replaces all PHYSICS/SOLEIL/* devices
     # ------------------------------------------------------------
     try:
@@ -256,7 +244,8 @@ def register_all_devices():
     except Exception as e:
         logger.error("❌ Failed to register RingSimulatorDevice: %s", e)
 
-    # ------------------------------------------------------------
+def _register_bpms(db: Database, unique_servers: set[tuple[str, str]]):
+    """Register BPM devices and properties."""
     # 4) BPM devices — one per Monitor element, read-only
     # ------------------------------------------------------------
     # Build s_pos → AT element index map by loading the lattice directly.
@@ -326,6 +315,40 @@ def register_all_devices():
 
     return sorted(unique_servers)
 
+def register_all_devices():
+    """
+    Register ALL Soleil devices in the Tango DB.
+
+    - Device *names* are the Soleil-style names (AN10-AR/EM/SCF.11, ...).
+    - For each device name:
+        domain  -> server_name
+        family  -> instance_name
+        server  -> f"{server_name}/{instance_name}"
+    - Also registers DServer devices for each (server_name, instance_name).
+
+    Returns:
+        list[(server_name, instance_name)] : all unique device servers to start.
+    """
+    db = Database()
+    unique_servers: set[tuple[str, str]] = set()
+
+    logger.info("📝 Registering ALL devices into Tango DB...")
+
+    _register_magnets(db, unique_servers)
+    _register_power_converters(db, unique_servers)
+    _register_cavities(db, unique_servers)
+    _register_ring_simulator(db, unique_servers)
+    _register_bpms(db, unique_servers)
+
+    logger.info("✔ Unique (server_name, instance_name) pairs: %s", unique_servers)
+    logger.info("✔ Device registration DONE. We have %d servers to start.", len(unique_servers))
+
+    # ------------------------------------------------------------
+    # 5) Make sure dserver/<server_name>/<instance_name> exists
+    # ------------------------------------------------------------
+    _register_dservers(db, unique_servers)
+
+    return sorted(unique_servers)
 
 def get_all_device_classes():
     """Return all device classes used by the servers."""

--- a/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
+++ b/src/dt4acc/custom_tango/ioc/devices/tango_device_setup.py
@@ -19,6 +19,7 @@ from dt4acc.custom_tango.ioc.devices.cavity_device import CavityDevice
 from dt4acc.custom_tango.ioc.devices.virtual_devices import RingSimulatorDevice, RING_SIM_DEV
 from dt4acc.custom_tango.ioc.devices.power_converter_device import PowerConverterDevice
 from dt4acc.custom_tango.ioc.devices.bpm_device import BPMDevice
+from dt4acc.custom_tango.ioc.mexec_server_for_physics_engine import EXPECTED_VIEW
 from dt4acc_lib.model.utils.tango_resource_locator import TangoResourceLocator
 
 logger = get_logger()
@@ -130,7 +131,6 @@ def build_device_plan() -> DevicePlan:
             )
 
     # Power converters
-    from dt4acc.custom_tango.ioc.server_manager import EXPECTED_VIEW
     if EXPECTED_VIEW == "device":
         seen = set()
         for pc_name in get_unique_power_converters():
@@ -397,7 +397,6 @@ def _register_power_converters(db: Database, unique_servers: set[tuple[str, str]
     # 2) Power converters — device view only.
     #    In design view the magnet device is the control source — no PC devices.
     # ------------------------------------------------------------
-    from dt4acc.custom_tango.ioc.server_manager import EXPECTED_VIEW
     if EXPECTED_VIEW == "device":
         registered_pcs = set()
         for pc_name in get_unique_power_converters():
@@ -625,3 +624,14 @@ def get_all_device_classes():
         RingSimulatorDevice,
         BPMDevice,
     ]
+
+
+def main():
+    import pprint
+
+    servers = register_all_devices()
+    print("Registered %d servers", len(servers))
+    pprint.pprint(servers, compact=True)
+
+if __name__ == "__main__":
+    main()

--- a/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
+++ b/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
@@ -9,6 +9,8 @@ Single virtual Tango device for the digital twin:
 """
 
 import asyncio
+from typing import Tuple
+
 import numpy as np
 from tango import DevState, DevFailed, DevDouble, DevString
 from tango.server import Device, attribute, command, AttrDataFormat, device_property, AttrWriteType
@@ -32,9 +34,12 @@ _orbit_x_cache: np.ndarray = np.array([], dtype=np.float64)
 _orbit_y_cache: np.ndarray = np.array([], dtype=np.float64)
 
 
-def get_orbit_at_index(index: int):
+def get_orbit_at_index(index: int) -> Tuple[float, float]:
     """Return (x, y) from the latest orbit cache at the given AT element index.
     Returns (0.0, 0.0) if the cache is empty or index is out of range.
+
+    Todo:
+        consider if it should rather return (math.nan, math.nan) if it fails
     """
     if index < len(_orbit_x_cache) and index < len(_orbit_y_cache):
         return float(_orbit_x_cache[index]), float(_orbit_y_cache[index])

--- a/src/dt4acc/custom_tango/ioc/handle_lattice.py
+++ b/src/dt4acc/custom_tango/ioc/handle_lattice.py
@@ -22,6 +22,9 @@ class LatticeLoader:
             )
         return _load_lattice(self.path)
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.path!r})"
+
 
 def _load_lattice(path: Path):
     """

--- a/src/dt4acc/custom_tango/ioc/mexec_config.py
+++ b/src/dt4acc/custom_tango/ioc/mexec_config.py
@@ -1,0 +1,3 @@
+_MANAGER_HOST = "127.0.0.1"
+_MANAGER_PORT = 50200
+_MANAGER_AUTHKEY = b"dt4acc-tango-secret"

--- a/src/dt4acc/custom_tango/ioc/mexec_server_for_physics_engine.py
+++ b/src/dt4acc/custom_tango/ioc/mexec_server_for_physics_engine.py
@@ -1,0 +1,110 @@
+import asyncio
+import logging
+import multiprocessing.managers
+import threading
+
+from dt4acc.core.utils.logger import get_logger
+from dt4acc.custom_tango.ioc.handle_lattice import lattice_loader
+from dt4acc.custom_tango.ioc.mexec_config import _MANAGER_HOST, _MANAGER_PORT, _MANAGER_AUTHKEY
+from dt4acc.custom_tango.ioc.sync_mexec_proxy import SyncMexecProxy
+from dt4acc.custom_tango.ioc.virtual_pass_through_command_rewriter import VirtualPassthroughCommandRewriter
+from dt4acc_lib.pyat_simulator.accelerator_simulator import PyATAcceleratorSimulator
+from dt4acc_lib.pyat_simulator.simulator_backend import SimulatorBackend
+
+# Suppress transitions state machine INFO logs across all processes
+logging.getLogger("transitions").setLevel(logging.WARNING)
+logging.getLogger("transitions.core").setLevel(logging.WARNING)
+
+logger = get_logger()
+
+# Callable that returns (yellow_pages, liaison_manager, translator_service)
+LOAD_MANAGERS_FN = None
+
+# Expected view for output — "design" for SOLEIL (commands in lattice space)
+EXPECTED_VIEW = "design"
+
+
+def _get_load_managers():
+    """Return the load_managers callable set by the launch script."""
+    if LOAD_MANAGERS_FN is None:
+        raise ValueError(
+            f"LOAD_MANAGERS_FN not set — set {__name__}.LOAD_MANAGERS_FN "
+            "in the launch script before calling main()"
+        )
+    return LOAD_MANAGERS_FN
+
+
+def _build_mexec():
+    """Build the TranslatingCommandExecutionEngine on the service process."""
+    from dt4acc.core.bl.translating_command_execution_engine import (
+        TranslatingCommandExecutionEngine,
+    )
+
+    acc = lattice_loader.load()
+    backend = SimulatorBackend(
+        name="Facility specific PYAT",
+        acc=PyATAcceleratorSimulator(at_lattice=acc),
+    )
+    load_managers = _get_load_managers()
+    _, lm, ts = load_managers()
+
+    cmd_rewriter = VirtualPassthroughCommandRewriter(liaison_manager=lm, translation_service=ts)
+
+    return TranslatingCommandExecutionEngine(
+        backend=backend,
+        cmd_rewriter=cmd_rewriter,
+        expected_view_for_output=EXPECTED_VIEW,
+        num_readings=1,
+    )
+
+# ---------------------------------------------------------------------------
+# MexecService — one process, one lattice, one mexec
+# ---------------------------------------------------------------------------
+class MexecManagerService(multiprocessing.managers.BaseManager):
+    pass
+
+
+def _run_mexec_service():
+    """
+    Entry point for the MexecService process.
+    """
+    service_loop = asyncio.new_event_loop()
+
+    def _run_loop():
+        asyncio.set_event_loop(service_loop)
+        service_loop.run_forever()
+
+    threading.Thread(target=_run_loop, daemon=True, name="mexec-service-loop").start()
+
+    future = asyncio.run_coroutine_threadsafe(_async_build_mexec(), service_loop)
+    mexec = future.result(timeout=120)
+    logger.warning("MexecService: lattice ready, mexec built.")
+
+
+    proxy = SyncMexecProxy(mexec=mexec, service_loop=service_loop)
+    MexecManagerService.register("get_mexec_proxy", callable=lambda: proxy)
+    MexecManagerService.register("sync_reset", callable=proxy.sync_reset)
+    MexecManagerService.register("sync_peek", callable=proxy.sync_peek)
+
+    mgr = MexecManagerService(
+        address=(_MANAGER_HOST, _MANAGER_PORT),
+        authkey=_MANAGER_AUTHKEY,
+    )
+    mgr.get_server().serve_forever()
+
+
+async def _async_build_mexec():
+    return _build_mexec()
+
+
+def _connect_to_mexec_service():
+    MexecManagerService.register("get_mexec_proxy")
+    MexecManagerService.register("sync_reset")
+    MexecManagerService.register("sync_peek")
+    client = MexecManagerService(
+        address=(_MANAGER_HOST, _MANAGER_PORT),
+        authkey=_MANAGER_AUTHKEY,
+    )
+    client.connect()
+    return client.get_mexec_proxy(), client.sync_reset
+

--- a/src/dt4acc/custom_tango/ioc/server_manager.py
+++ b/src/dt4acc/custom_tango/ioc/server_manager.py
@@ -36,10 +36,15 @@ import time
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+import select
+from tango import DeviceProxy, DevFailed
+
 from dt4acc.custom_tango.ioc.mexec_server_for_physics_engine import _run_mexec_service, _connect_to_mexec_service
-
-
+from dt4acc.custom_tango.ioc.devices.tango_device_setup import register_all_devices, ensure_devices
+from dt4acc.custom_tango.ioc.devices.virtual_devices import RING_SIM_DEV
+from dt4acc.custom_tango.ioc import single_server
 from dt4acc.core.utils.logger import get_logger
+
 
 logger = get_logger()
 
@@ -53,6 +58,7 @@ logger = get_logger()
 # Heartbeat — pure recalculation, no lattice writes, no noise
 # Set by the launch script. Period in seconds (0 = disabled).
 HEARTBEAT_PERIOD = 1.0
+
 
 # ---------------------------------------------------------------------------
 # Calculation heartbeat — no writes, no lattice perturbation
@@ -91,8 +97,6 @@ def _calculation_heartbeat(start_evt, stop_evt, period_s=1.0):
     logger.warning("Calculation heartbeat started — recalculating every %.1fs", period_s)
 
     # Connect to the RingSimulatorDevice to trigger recalculation via Recalculate command
-    from tango import DeviceProxy, DevFailed
-    from dt4acc.custom_tango.ioc.devices.virtual_devices import RING_SIM_DEV
 
     dev = None
     while not stop_evt.is_set():
@@ -188,14 +192,24 @@ def main():
         sys.exit(1)
 
     # 2. Register Tango devices in DB
-    from dt4acc.custom_tango.ioc.devices.tango_device_setup import register_all_devices
-    servers = register_all_devices()
-    logger.warning("DB registration done. Starting %d servers.", len(servers))
+    # single_server_args = register_all_devices()
+    single_server_args = ensure_devices(register_missing=False)
+    simulator_server_args = [args for args in single_server_args if args[0] == "simulator"]
+    device_server_args = single_server_args.copy()
+    for arg in simulator_server_args:
+        device_server_args.remove(arg)
+    # selected device server args: just here to start some of them earlier
+    # should be rather started on the commandline.
+    selected_device_server_args = [args for args in device_server_args if args[1].endswith("DIP")]
+    other_device_server_args = device_server_args.copy()
+    for arg in selected_device_server_args:
+        other_device_server_args.remove(arg)
+    logger.warning("DB registration done. Starting %d single_servers.", len(single_server_args))
 
     # 3. Spawn one Tango server process per (server_name, instance_name)
-    from dt4acc.custom_tango.ioc import single_server
     monitors = []
-    for server_name, instance_name in servers:
+    # Start first simulator services then the device servers
+    for server_name, instance_name in simulator_server_args + selected_device_server_args + other_device_server_args:
         evt = mp.Event()
         p = mp.Process(
             target=single_server.main_loop,

--- a/src/dt4acc/custom_tango/ioc/server_manager.py
+++ b/src/dt4acc/custom_tango/ioc/server_manager.py
@@ -54,25 +54,6 @@ logger = get_logger()
 # Set by the launch script. Period in seconds (0 = disabled).
 HEARTBEAT_PERIOD = 1.0
 
-
-
-# ---------------------------------------------------------------------------
-# Heartbeat
-# ---------------------------------------------------------------------------
-
-def _wait_for_heartbeat_start(start_evt, stop_evt):
-    start = time.time()
-    for cnt in itertools.count():
-        if start_evt.is_set():
-            return True
-        if stop_evt.is_set():
-            return False
-        time.sleep(0.2)
-        if (cnt % (5 * 30)) == 0:
-            dt = (time.time() - start) / 60
-            logger.warning("%.1f min: waiting for tango devices to start", dt)
-
-
 # ---------------------------------------------------------------------------
 # Calculation heartbeat — no writes, no lattice perturbation
 # ---------------------------------------------------------------------------

--- a/src/dt4acc/custom_tango/ioc/server_manager.py
+++ b/src/dt4acc/custom_tango/ioc/server_manager.py
@@ -26,12 +26,8 @@ Process topology
         and verify the system is alive end-to-end.
 """
 
-import asyncio
 import itertools
-import logging
 import multiprocessing as mp
-import multiprocessing.managers
-import multiprocessing.synchronize
 import os
 import signal
 import sys
@@ -40,25 +36,12 @@ import time
 from dataclasses import dataclass
 from typing import Any, Sequence
 
-from dt4acc.custom_tango.ioc.handle_lattice import lattice_loader
-from dt4acc.custom_tango.ioc.sync_mexec_proxy import SyncMexecProxy
-from dt4acc.custom_tango.ioc.virtual_pass_through_command_rewriter import VirtualPassthroughCommandRewriter
+from dt4acc.custom_tango.ioc.mexec_server_for_physics_engine import _run_mexec_service, _connect_to_mexec_service
 
-# Suppress transitions state machine INFO logs across all processes
-logging.getLogger("transitions").setLevel(logging.WARNING)
-logging.getLogger("transitions.core").setLevel(logging.WARNING)
-
-
-from dt4acc_lib.pyat_simulator.accelerator_simulator import PyATAcceleratorSimulator
-from dt4acc_lib.pyat_simulator.simulator_backend import SimulatorBackend
 
 from dt4acc.core.utils.logger import get_logger
 
 logger = get_logger()
-
-_MANAGER_HOST = "127.0.0.1"
-_MANAGER_PORT = 50200
-_MANAGER_AUTHKEY = b"dt4acc-tango-secret"
 
 # ---------------------------------------------------------------------------
 # Facility configuration — set by the launch script before calling main()
@@ -66,106 +49,11 @@ _MANAGER_AUTHKEY = b"dt4acc-tango-secret"
 
 # Path to the AT lattice file (.m or .json)
 
-# Callable that returns (yellow_pages, liaison_manager, translator_service)
-LOAD_MANAGERS_FN = None
-
-# Expected view for output — "design" for SOLEIL (commands in lattice space)
-EXPECTED_VIEW = "design"
 
 # Heartbeat — pure recalculation, no lattice writes, no noise
 # Set by the launch script. Period in seconds (0 = disabled).
 HEARTBEAT_PERIOD = 1.0
 
-
-def _get_load_managers():
-    """Return the load_managers callable set by the launch script."""
-    if LOAD_MANAGERS_FN is None:
-        raise ValueError(
-            "LOAD_MANAGERS_FN not set — set server_manager.LOAD_MANAGERS_FN "
-            "in the launch script before calling main()"
-        )
-    return LOAD_MANAGERS_FN
-
-
-# ---------------------------------------------------------------------------
-# MexecService — one process, one lattice, one mexec
-# ---------------------------------------------------------------------------
-
-class MexecManagerService(multiprocessing.managers.BaseManager):
-    pass
-
-
-def _build_mexec():
-    """Build the TranslatingCommandExecutionEngine on the service process."""
-    from dt4acc.core.bl.translating_command_execution_engine import (
-        TranslatingCommandExecutionEngine,
-    )
-
-    acc = lattice_loader.load()
-    backend = SimulatorBackend(
-        name="Facility specific PYAT",
-        acc=PyATAcceleratorSimulator(at_lattice=acc),
-    )
-    load_managers = _get_load_managers()
-    _, lm, ts = load_managers()
-
-    cmd_rewriter = VirtualPassthroughCommandRewriter(liaison_manager=lm, translation_service=ts)
-
-    return TranslatingCommandExecutionEngine(
-        backend=backend,
-        cmd_rewriter=cmd_rewriter,
-        expected_view_for_output=EXPECTED_VIEW,
-        num_readings=1,
-    )
-
-
-def _run_mexec_service():
-    """
-    Entry point for the MexecService process.
-    """
-    import logging
-    logging.getLogger("transitions").setLevel(logging.WARNING)
-    logging.getLogger("transitions.core").setLevel(logging.WARNING)
-
-    service_loop = asyncio.new_event_loop()
-
-    def _run_loop():
-        asyncio.set_event_loop(service_loop)
-        service_loop.run_forever()
-
-    threading.Thread(target=_run_loop, daemon=True, name="mexec-service-loop").start()
-
-    future = asyncio.run_coroutine_threadsafe(_async_build_mexec(), service_loop)
-    mexec = future.result(timeout=120)
-    logger.warning("MexecService: lattice ready, mexec built.")
-
-
-    proxy = SyncMexecProxy(mexec=mexec, service_loop=service_loop)
-    MexecManagerService.register("get_mexec_proxy", callable=lambda: proxy)
-    MexecManagerService.register("sync_reset", callable=proxy.sync_reset)
-    MexecManagerService.register("sync_peek", callable=proxy.sync_peek)
-
-    mgr = MexecManagerService(
-        address=(_MANAGER_HOST, _MANAGER_PORT),
-        authkey=_MANAGER_AUTHKEY,
-    )
-    mgr.get_server().serve_forever()
-
-
-async def _async_build_mexec():
-    return _build_mexec()
-
-
-def _connect_to_mexec_service():
-    MexecManagerService.register("get_mexec_proxy")
-    MexecManagerService.register("sync_reset")
-    MexecManagerService.register("sync_peek")
-    client = MexecManagerService(
-        address=(_MANAGER_HOST, _MANAGER_PORT),
-        authkey=_MANAGER_AUTHKEY,
-    )
-    client.connect()
-    return client.get_mexec_proxy(), client.sync_reset
 
 
 # ---------------------------------------------------------------------------

--- a/src/dt4acc/custom_tango/ioc/single_server.py
+++ b/src/dt4acc/custom_tango/ioc/single_server.py
@@ -27,13 +27,7 @@ from dt4acc_lib.model.utils.tango_resource_locator import TangoResourceLocator
 from dt4acc.config.data.querries import get_unique_power_converters, get_magnets_per_power_converters
 from dt4acc.core.bl.controller import Controller
 from dt4acc.custom_tango.views.view import TangoView
-from dt4acc.custom_tango.ioc.server_manager import _connect_to_mexec_service
-
-# Suppress transitions state machine INFO logs — they fire on every
-# backend.set() call and flood the output (4 lines per state transition)
-logging.getLogger("transitions").setLevel(logging.WARNING)
-logging.getLogger("transitions.core").setLevel(logging.WARNING)
-
+from dt4acc.custom_tango.ioc.mexec_server_for_physics_engine import _connect_to_mexec_service
 from dt4acc_lib.model.output.result import TranslatedReading, ReadTogetherAndTranslated, SingleReading
 from dt4acc_lib.model.utils.command import ReadCommand, Command
 from tango.server import run
@@ -41,6 +35,11 @@ from tango.server import run
 from dt4acc.core.utils.logger import get_logger
 from dt4acc.custom_tango.ioc.controller_registry import set_controller, get_controller
 from dt4acc.custom_tango.ioc.tango_controller import TangoController, DEFAULT_DELAYED_READS
+
+# Suppress transitions state machine INFO logs — they fire on every
+# backend.set() call and flood the output (4 lines per state transition)
+logging.getLogger("transitions").setLevel(logging.WARNING)
+logging.getLogger("transitions.core").setLevel(logging.WARNING)
 
 logger = get_logger()
 
@@ -267,6 +266,8 @@ def main_loop(server_name: str, instance_name: str, event=None):
     logging.getLogger("transitions").setLevel(logging.WARNING)
     logging.getLogger("transitions.core").setLevel(logging.WARNING)
 
+    logger.warning("single server start: name %s instance %s", server_name, instance_name)
+
     os.nice(4)
 
     prefix = os.environ.get("DT4ACC_PREFIX", os.getlogin())
@@ -364,6 +365,7 @@ def main():
     if len(sys.argv) != 3:
         print("Usage: single_server.py <server_name> <instance_name>")
         sys.exit(1)
+    logger.warning("cli: single server start: name %s instance %s", sys.argv[1], sys.argv[2])
     main_loop(server_name=sys.argv[1], instance_name=sys.argv[2])
 
 

--- a/src/dt4acc/custom_tango/ioc/tango_controller.py
+++ b/src/dt4acc/custom_tango/ioc/tango_controller.py
@@ -142,7 +142,7 @@ class TangoController(ControllerInterface):
             from dt4acc.custom_tango.ioc.single_server import (
                 refresh_cache_from_lattice, _my_magnet_uuids, _uuid_to_prop
             )
-            from dt4acc.custom_tango.ioc.server_manager import _connect_to_mexec_service
+            from dt4acc.custom_tango.ioc.mexec_server_for_physics_engine import _connect_to_mexec_service
             sync_proxy, _ = _connect_to_mexec_service()
             refresh_cache_from_lattice(sync_proxy, _my_magnet_uuids, _uuid_to_prop)
 


### PR DESCRIPTION
Split up into:

Have a look to custom_facility/soleil  for an implementation

- register devices: 
    - registers devices in the tango database
    - or  checks if devices are there. This check does not include if the device has all attributes it should and so on
    - allows dumping a list. Each list entry contains the two arguments you need to start the single server
- run_soleil_physics_twin: start only the simulator with its multiprocessing interface (no tango view)
- single_server: starts the single tango server or view. Arguments can be obtained by register_devices. Please note that a Tango view needs also be started for the simulation engine
- run_soleil_twin: starts all at once: please note that it now assumes that all devices are already registered in the database. It will not register them itself


