### PR TITLE
[FIX] server manager: start all processes not only some of them

### DIFF
--- a/src/dt4acc/custom_tango/ioc/server_manager.py
+++ b/src/dt4acc/custom_tango/ioc/server_manager.py
@@ -210,7 +210,7 @@ def main():
     # 3. Spawn one Tango server process per (server_name, instance_name)
     monitors = []
     # Start first simulator services then the device servers
-    for server_name, instance_name in simulator_server_args + selected_device_server_args[:2]: # + other_device_server_args:
+    for server_name, instance_name in simulator_server_args + selected_device_server_args + other_device_server_args:
         evt = mp.Event()
         p = mp.Process(
             target=single_server.main_loop,


### PR DESCRIPTION
server manager / run_..._twin should provide some command line options to control this start