### PR TITLE
Bugfix for reinit

### DIFF
--- a/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
+++ b/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
@@ -258,11 +258,11 @@ class RingSimulatorDevice(Device, AsyncMixin):
         """Map backend calculation state to Tango device state (color in Jive)."""
         backend_state = get_controller().get_backend_state()
         if backend_state == CalculationStates.error:
-            self.set_state(DevState.FAULT)
-            self.set_status("Backend error: optics calculation failed.")
+            self.set_state(DevState.ALARM)
+            self.set_status("Beam loss: optics calculation failed. Call Reset or Reinit.")
         elif backend_state == CalculationStates.acknowledged:
             self.set_state(DevState.ALARM)
-            self.set_status("Acknowledged: optics calculation failed. Call Reset or Reinit.")
+            self.set_status("Beam loss acknowledged. Call Reset or Reinit.")
         else:
             self.set_state(DevState.ON)
             self.set_status("Running")
@@ -300,21 +300,6 @@ class RingSimulatorDevice(Device, AsyncMixin):
             logger.warning("RingSimulatorDevice.Reset: complete — recalculation queued")
         except Exception as exc:
             logger.error("RingSimulatorDevice.Reset failed: %s", exc)
-            self.set_state(DevState.FAULT)
-            raise DevFailed(str(exc))
-
-    @command
-    def Acknowledge(self):
-        """Acknowledge that the calculation engine is in error mode """
-        logger.warning("RingSimulatorDevice.Acknowledge: acknowledge engine is in error mode")
-        self.set_state(DevState.INIT)
-        try:
-            self._start_async()
-            get_controller().acknowledge()
-            self.set_state(DevState.ON)
-            logger.warning("RingSimulatorDevice.Acknowledge: complete")
-        except Exception as exc:
-            logger.error("RingSimulatorDevice.Acknowledge failed: %s", exc)
             self.set_state(DevState.FAULT)
             raise DevFailed(str(exc))
 

--- a/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
+++ b/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
@@ -297,7 +297,7 @@ class RingSimulatorDevice(Device, AsyncMixin):
             self._start_async()
             get_controller().reset()
             self.set_state(DevState.ON)
-            logger.warning("RingSimulatorDevice.Reset: complete — nominal state restored")
+            logger.warning("RingSimulatorDevice.Reset: complete — recalculation queued")
         except Exception as exc:
             logger.error("RingSimulatorDevice.Reset failed: %s", exc)
             self.set_state(DevState.FAULT)
@@ -312,7 +312,7 @@ class RingSimulatorDevice(Device, AsyncMixin):
             self._start_async()
             get_controller().acknowledge()
             self.set_state(DevState.ON)
-            logger.warning("RingSimulatorDevice.Acknowledge: complete — nominal state restored")
+            logger.warning("RingSimulatorDevice.Acknowledge: complete")
         except Exception as exc:
             logger.error("RingSimulatorDevice.Acknowledge failed: %s", exc)
             self.set_state(DevState.FAULT)

--- a/src/dt4acc/custom_tango/ioc/mexec_server_for_physics_engine.py
+++ b/src/dt4acc/custom_tango/ioc/mexec_server_for_physics_engine.py
@@ -97,6 +97,7 @@ def _run_mexec_service():
     proxy = SyncMexecProxy(mexec=mexec, service_loop=service_loop)
     MexecManagerService.register("get_mexec_proxy", callable=lambda: proxy)
     MexecManagerService.register("sync_reset", callable=proxy.sync_reset)
+    MexecManagerService.register("sync_reinit", callable=proxy.sync_reinit)
     MexecManagerService.register("sync_peek", callable=proxy.sync_peek)
 
     mgr = MexecManagerService(
@@ -113,10 +114,11 @@ async def _async_build_mexec():
 def _connect_to_mexec_service():
     MexecManagerService.register("get_mexec_proxy")
     MexecManagerService.register("sync_reset")
+    MexecManagerService.register("sync_reinit")
     MexecManagerService.register("sync_peek")
     client = MexecManagerService(
         address=(mexec_config._MANAGER_HOST, mexec_config._MANAGER_PORT),
         authkey=mexec_config._MANAGER_AUTHKEY,
     )
     client.connect()
-    return client.get_mexec_proxy(), client.sync_reset
+    return client.get_mexec_proxy(), client.sync_reset, client.sync_reinit

--- a/src/dt4acc/custom_tango/ioc/single_server.py
+++ b/src/dt4acc/custom_tango/ioc/single_server.py
@@ -249,7 +249,7 @@ def _inject_controller(prefix: str) -> None:
     Build AsyncMexecAdapter + TangoController and register in controller_registry.
     Called before tango.server.run() so init_device() can call get_controller().
     """
-    sync_proxy, sync_reset = _connect_to_mexec_service()
+    sync_proxy, sync_reset, sync_reinit = _connect_to_mexec_service()
     global _sync_proxy
     _sync_proxy = sync_proxy
     mexec = AsyncMexecAdapter(sync_proxy)
@@ -264,6 +264,7 @@ def _inject_controller(prefix: str) -> None:
             view = TangoView(prefix=prefix),
             ),
             sync_reset = sync_reset,
+            sync_reinit = sync_reinit,
     )
 
     set_controller(controller)
@@ -289,7 +290,7 @@ def main_loop(server_name: str, instance_name: str, event=None):
     # Bulk pre-load initial values for all magnets in this server/instance.
     # One RPC call for all magnets instead of one per magnet in init_device().
     try:
-        sync_proxy, _ = _connect_to_mexec_service()
+        sync_proxy, _, _ = _connect_to_mexec_service()
 
         # Collect UUIDs for magnets belonging to this server/instance
         my_uuids = []

--- a/src/dt4acc/custom_tango/ioc/sync_mexec_proxy.py
+++ b/src/dt4acc/custom_tango/ioc/sync_mexec_proxy.py
@@ -88,12 +88,9 @@ class SyncMexecProxy:
 
     def sync_reset(self):
         """
-        Reset backend to nominal state:
-        1. Reload AT lattice from .m file
-        2. Clear error state → pending
-        3. Clear stored optics
+        Clear backend error state and stored optics without reloading the lattice.
         """
-        logger.warning("SyncMexecProxy.sync_reset: resetting back end (pid = %d)", os.getpid())
+        logger.warning("SyncMexecProxy.sync_reset: clearing backend state (pid = %d)", os.getpid())
         try:
             fut = asyncio.run_coroutine_threadsafe(
                 self.mexec.backend.reset(), self.service_loop
@@ -125,10 +122,21 @@ class SyncMexecProxy:
     def sync_acknowledge(self):
         logger.warning("SyncMexecProxy.sync_acknowledge: acknowledging error")
         try:
-            fut = asyncio.run_coroutine_threadsafe(
-                self.mexec.backend.acknowledge(), self.service_loop
-            )
-            fut.result(timeout=30)
+            async def _acknowledge_if_error():
+                state = self.mexec.backend.get_state()
+                if state == CalculationStates.error:
+                    await self.mexec.backend.acknowledge()
+                    return True, state
+                return False, state
+
+            fut = asyncio.run_coroutine_threadsafe(_acknowledge_if_error(), self.service_loop)
+            acknowledged, state = fut.result(timeout=30)
+            if not acknowledged:
+                logger.warning(
+                    "SyncMexecProxy.sync_acknowledge: backend state is %s, nothing to acknowledge",
+                    state,
+                )
+                return
             logger.warning("SyncMexecProxy.sync_acknowledge: backend acknowledge done")
         except Exception as exc:
             logger.error("SyncMexecProxy.sync_acknowledge failed: %s", exc)

--- a/src/dt4acc/custom_tango/ioc/tango_controller.py
+++ b/src/dt4acc/custom_tango/ioc/tango_controller.py
@@ -92,13 +92,15 @@ class TangoController(ControllerInterface):
         # prefix: str,
         # default_delayed_reads: Sequence[ReadCommand] = DEFAULT_DELAYED_READS,
         sync_reset=None,
+        sync_reinit=None,
     ):
         self.delegate = controller_delegate
         self.name = name
 
         # a missing link to get running again ?
         self.mexec = self.delegate.mexec
-        self._sync_reset = sync_reset  # callable: reloads lattice + clears error state
+        self._sync_reset = sync_reset  # callable: clears error state
+        self._sync_reinit = sync_reinit  # callable: reloads lattice + clears error state
 
         self.cmd_queue: asyncio.Queue = None  # created in start() on running loop
         self._pending_task = None
@@ -107,11 +109,14 @@ class TangoController(ControllerInterface):
         return self.mexec.get_state()
 
     def reinit(self) -> None:
-        if self._sync_reset is None:
-            raise RuntimeError("TangoController: no sync_reset callable registered")
-        logger.warning("TangoController.reinit resetting backend to nominal state...")
+        if self._sync_reinit is None:
+            raise RuntimeError("TangoController: no sync_reinit callable registered")
+        logger.warning("TangoController.reinit: reinitialising backend to nominal state...")
 
         shared_loop = get_shared_event_loop()
+
+        # Reload lattice + clear error state
+        self._sync_reinit()
 
         # Queue fresh full calculation
         asyncio.run_coroutine_threadsafe(
@@ -122,7 +127,7 @@ class TangoController(ControllerInterface):
         # Refresh all MagnetDevice local attributes from the reloaded lattice
         self._refresh_all_magnet_devices()
 
-        logger.warning("TangoController.reset: done — recalculation queued")
+        logger.warning("TangoController.reinit: done — recalculation queued")
 
     def acknowledge(self) -> None:
         logger.warning("TangoController.acknowledge: acknowledge that calculation engine in error state ...")
@@ -143,7 +148,7 @@ class TangoController(ControllerInterface):
 
     def reset(self) -> None:
         """
-        Reset backend to nominal state and trigger fresh calculations.
+        Clear backend error state and trigger fresh calculations on the current lattice.
         Called from TwissOrbitDevice.Reset command.
 
         NOTE: Do NOT call push_invalid() here — Reset runs inside the
@@ -154,11 +159,11 @@ class TangoController(ControllerInterface):
         """
         if self._sync_reset is None:
             raise RuntimeError("TangoController: no sync_reset callable registered")
-        logger.warning("TangoController.reset: resetting backend to nominal state...")
+        logger.warning("TangoController.reset: clearing backend state...")
 
         shared_loop = get_shared_event_loop()
 
-        # Reload lattice + clear error state
+        # Clear error state
         self._sync_reset()
 
         # Queue fresh full calculation
@@ -181,7 +186,7 @@ class TangoController(ControllerInterface):
             from dt4acc.custom_tango.ioc.single_server import (
                 refresh_cache_from_lattice, _my_magnet_uuids, _uuid_to_prop
             )
-            sync_proxy, _ = _connect_to_mexec_service()
+            sync_proxy, _, _ = _connect_to_mexec_service()
             refresh_cache_from_lattice(sync_proxy, _my_magnet_uuids, _uuid_to_prop)
 
             from tango import Database, DeviceProxy


### PR DESCRIPTION
Fix Tango recovery after optics failures. Reinit now reaches the central backend through sync_reinit, reloads the nominal lattice, and queues fresh readings. Also makes backend acknowledge calls idempotent to avoid concurrent Tango servers flooding errors.