### PR TITLE
Initialize Tango writable setpoints from lattice state.

### DIFF
--- a/src/dt4acc/custom_tango/ioc/devices/base_magnet_device.py
+++ b/src/dt4acc/custom_tango/ioc/devices/base_magnet_device.py
@@ -15,6 +15,7 @@ from tango.server import Device, device_property
 from dt4acc.core.utils.logger import get_logger
 from dt4acc.custom_tango.ioc.controller_registry import get_controller
 from dt4acc.core.bl.shared_event_loop import get_shared_event_loop
+from dt4acc.custom_tango.ioc.devices.write_value_sync import sync_write_value
 
 logger = get_logger()
 
@@ -84,3 +85,6 @@ class BaseMagnetDevice(Device):
                 delayed_reads=[],
             )
         )
+
+    def _sync_write_value(self, attr_name: str, value) -> None:
+        sync_write_value(self, attr_name, value)

--- a/src/dt4acc/custom_tango/ioc/devices/cavity_device.py
+++ b/src/dt4acc/custom_tango/ioc/devices/cavity_device.py
@@ -22,8 +22,12 @@ class CavityDevice(BaseMagnetDevice):
 
     def init_device(self):
         super().init_device()
-        self._frequency = 0.0
-        self._voltage = 0.0
+        from dt4acc.custom_tango.ioc.single_server import get_initial_values
+        vals = get_initial_values(self.lattice_id)
+        self._frequency = vals.get("frequency", 0.0)
+        self._voltage = vals.get("voltage", 0.0)
+        self._sync_write_value("frequency", self._frequency)
+        self._sync_write_value("voltage", self._voltage)
 
     @attribute(dtype=float, access=AttrWriteType.READ_WRITE,
                label="Frequency", unit="Hz")
@@ -57,10 +61,13 @@ class CavityDevice(BaseMagnetDevice):
     @command
     def RefreshFromCache(self) -> None:
         try:
-            from dt4acc.custom_tango.ioc.single_server import get_nominal_values
+            from dt4acc.custom_tango.ioc.single_server import refresh_one_from_lattice, get_nominal_values
+            refresh_one_from_lattice(self.lattice_id)
             vals = get_nominal_values(self.lattice_id)
             self._frequency = vals.get("frequency", 0.0)
             self._voltage   = vals.get("voltage",   0.0)
+            self._sync_write_value("frequency", self._frequency)
+            self._sync_write_value("voltage", self._voltage)
             logger.info("%s: RefreshFromCache done — frequency=%.3f voltage=%.3f",
                         self.magnet_name, self._frequency, self._voltage)
         except Exception as exc:

--- a/src/dt4acc/custom_tango/ioc/devices/multipole_device.py
+++ b/src/dt4acc/custom_tango/ioc/devices/multipole_device.py
@@ -30,9 +30,12 @@ class MultipoleDevice(BaseMagnetDevice):
 
     def init_device(self):
         super().init_device()
-        from dt4acc.custom_tango.ioc.single_server import get_initial_strength
-        self._magnetic_strength = get_initial_strength(self.lattice_id)
+        from dt4acc.custom_tango.ioc.single_server import get_initial_values
+        vals = get_initial_values(self.lattice_id)
+        self._magnetic_strength = vals.get(self.lattice_property,
+                                           vals.get("main_strength", 0.0))
         self._magnetic_strength_readback = self._magnetic_strength
+        self._sync_write_value("magnetic_strength", self._magnetic_strength)
 
     @attribute(dtype=float, access=AttrWriteType.READ_WRITE,
                label="Magnetic strength", unit="1/m",
@@ -70,11 +73,13 @@ class MultipoleDevice(BaseMagnetDevice):
     def RefreshFromCache(self) -> None:
         """Read nominal values from process-local cache after system reset."""
         try:
-            from dt4acc.custom_tango.ioc.single_server import get_nominal_values
+            from dt4acc.custom_tango.ioc.single_server import refresh_one_from_lattice, get_nominal_values
+            refresh_one_from_lattice(self.lattice_id)
             vals = get_nominal_values(self.lattice_id)
             self._magnetic_strength = vals.get(self.lattice_property,
                                                vals.get("main_strength", 0.0))
             self._magnetic_strength_readback = self._magnetic_strength
+            self._sync_write_value("magnetic_strength", self._magnetic_strength)
             logger.info("%s: RefreshFromCache done — strength=%.6f",
                         self.magnet_name, self._magnetic_strength)
         except Exception as exc:

--- a/src/dt4acc/custom_tango/ioc/devices/power_converter_device.py
+++ b/src/dt4acc/custom_tango/ioc/devices/power_converter_device.py
@@ -4,11 +4,12 @@ from dt4acc.core.bl.shared_event_loop import get_shared_event_loop
 from dt4acc_lib.model.utils import tango_resource_locator
 from dt4acc_lib.model.utils.command import BehaviourOnError, Command
 from tango import DevState, DevFailed
-from tango.server import Device, attribute, device_property, AttrWriteType
+from tango.server import Device, attribute, command, device_property, AttrWriteType
 
 from dt4acc.config.data.querries import get_magnets_per_power_converters
 from dt4acc.core.utils.logger import get_logger
 from dt4acc.custom_tango.ioc.controller_registry import get_controller
+from dt4acc.custom_tango.ioc.devices.write_value_sync import sync_write_value
 
 logger = get_logger()
 
@@ -52,6 +53,7 @@ class PowerConverterDevice(Device):
         self._current = self._peek_initial_current()
         self._current_rb = self._current
         self._voltage = 0.0
+        sync_write_value(self, "current_set", self._current)
 
         self.set_state(DevState.ON)
 
@@ -136,7 +138,42 @@ class CavityPowerConverterDevice(Device):
         self._cavity_uuids = [c["uuid"] for c in cavities if c.get("uuid")]
         logger.info("%s: controlling cavity UUIDs: %s", self.pc_name, self._cavity_uuids)
 
+        self._current = self._initial_cavity_voltage()
+        self._voltage = self._current
+        sync_write_value(self, "current_set", self._current)
+
         self.set_state(DevState.ON)
+
+    def _initial_cavity_voltage(self) -> float:
+        try:
+            from dt4acc.custom_tango.ioc.single_server import refresh_one_from_lattice, get_initial_values
+            for uuid in self._cavity_uuids:
+                refresh_one_from_lattice(uuid, ("voltage",))
+            voltages = [
+                get_initial_values(uuid).get("voltage", 0.0)
+                for uuid in self._cavity_uuids
+            ]
+            voltages = [float(v) for v in voltages if v is not None]
+            if voltages:
+                return sum(voltages) / len(voltages)
+        except Exception as exc:
+            logger.debug("%s: could not initialise RF PC voltage: %s", self.pc_name, exc)
+        return 0.0
+
+    @command
+    def RefreshFromCache(self) -> None:
+        try:
+            self._current = self._initial_cavity_voltage()
+            self._voltage = self._current
+            sync_write_value(self, "current_set", self._current)
+            logger.info(
+                "%s: RefreshFromCache done — current_set=%.3f voltage=%.3f",
+                self.pc_name,
+                self._current,
+                self._voltage,
+            )
+        except Exception as exc:
+            logger.error("%s: RefreshFromCache failed: %s", self.pc_name, exc)
 
     def _async(self, coro):
         try:

--- a/src/dt4acc/custom_tango/ioc/devices/skew_quad_device.py
+++ b/src/dt4acc/custom_tango/ioc/devices/skew_quad_device.py
@@ -35,7 +35,12 @@ class SkewQuadDevice(BaseMagnetDevice):
 
     def init_device(self):
         super().init_device()
-        self._corrector_strength = 0.0
+        from dt4acc.custom_tango.ioc.single_server import get_initial_values
+        self._corrector_strength = get_initial_values(self.lattice_id).get(
+            self.lattice_property,
+            0.0,
+        )
+        self._sync_write_value("corrector_strength", self._corrector_strength)
         logger.info("Initializing %s: %s lattice_id=%s lattice_property=%s",
                     self.__class__.__name__, self.get_name(),
                     self.lattice_id, self.lattice_property)
@@ -60,9 +65,11 @@ class SkewQuadDevice(BaseMagnetDevice):
     @command
     def RefreshFromCache(self) -> None:
         try:
-            from dt4acc.custom_tango.ioc.single_server import get_nominal_values
+            from dt4acc.custom_tango.ioc.single_server import refresh_one_from_lattice, get_nominal_values
+            refresh_one_from_lattice(self.lattice_id)
             vals = get_nominal_values(self.lattice_id)
             self._corrector_strength = vals.get(self.lattice_property, 0.0)
+            self._sync_write_value("corrector_strength", self._corrector_strength)
             logger.info("%s: RefreshFromCache done — corrector_strength=%.6f",
                         self.magnet_name, self._corrector_strength)
         except Exception as exc:

--- a/src/dt4acc/custom_tango/ioc/devices/steerer_device.py
+++ b/src/dt4acc/custom_tango/ioc/devices/steerer_device.py
@@ -28,7 +28,9 @@ class HorizontalSteererDevice(BaseMagnetDevice):
 
     def init_device(self):
         super().init_device()
-        self._x = 0.0
+        from dt4acc.custom_tango.ioc.single_server import get_initial_values
+        self._x = get_initial_values(self.lattice_id).get("x_kick", 0.0)
+        self._sync_write_value("x_kick", self._x)
 
     @attribute(dtype=float, access=AttrWriteType.READ_WRITE,
                label="Horizontal kick", unit="rad")
@@ -50,9 +52,11 @@ class HorizontalSteererDevice(BaseMagnetDevice):
     @command
     def RefreshFromCache(self) -> None:
         try:
-            from dt4acc.custom_tango.ioc.single_server import get_nominal_values
+            from dt4acc.custom_tango.ioc.single_server import refresh_one_from_lattice, get_nominal_values
+            refresh_one_from_lattice(self.lattice_id)
             vals = get_nominal_values(self.lattice_id)
-            self._x = vals["x_kick"]
+            self._x = vals.get("x_kick", 0.0)
+            self._sync_write_value("x_kick", self._x)
             logger.info("%s: RefreshFromCache done — x_kick=%.6f",
                         self.trl.as_trl(), self._x)
         except Exception as exc:
@@ -67,7 +71,9 @@ class VerticalSteererDevice(BaseMagnetDevice):
 
     def init_device(self):
         super().init_device()
-        self._y = 0.0
+        from dt4acc.custom_tango.ioc.single_server import get_initial_values
+        self._y = get_initial_values(self.lattice_id).get("y_kick", 0.0)
+        self._sync_write_value("y_kick", self._y)
 
     @attribute(dtype=float, access=AttrWriteType.READ_WRITE,
                label="Vertical kick", unit="rad")
@@ -89,9 +95,11 @@ class VerticalSteererDevice(BaseMagnetDevice):
     @command
     def RefreshFromCache(self) -> None:
         try:
-            from dt4acc.custom_tango.ioc.single_server import get_nominal_values
+            from dt4acc.custom_tango.ioc.single_server import refresh_one_from_lattice, get_nominal_values
+            refresh_one_from_lattice(self.lattice_id)
             vals = get_nominal_values(self.lattice_id)
-            self._y = vals["y_kick"]
+            self._y = vals.get("y_kick", 0.0)
+            self._sync_write_value("y_kick", self._y)
             logger.info("%s: RefreshFromCache done — y_kick=%.6f",
                         self.trl.as_trl(), self._y)
         except Exception as exc:

--- a/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
+++ b/src/dt4acc/custom_tango/ioc/devices/virtual_devices.py
@@ -21,6 +21,7 @@ from dt4acc_lib.interfaces.backend.calculation_states import CalculationStates
 from dt4acc_lib.model.utils.command import Command, BehaviourOnError, ReadCommand
 from dt4acc.core.utils.logger import get_logger
 from dt4acc.custom_tango.ioc.controller_registry import get_controller
+from dt4acc.custom_tango.ioc.devices.write_value_sync import sync_write_value
 
 logger = get_logger()
 
@@ -84,13 +85,48 @@ class RingSimulatorDevice(Device, AsyncMixin):
         self._tune_vert = 0.0
         self._xi_x      = 0.0
         self._xi_y      = 0.0
-        self._reference_frequency = 0.0
         self._rf_cavity_uuids = get_rf_cavity_uuids()
+        self._reference_frequency = self._initial_reference_frequency()
+        self._sync_write_value("reference_frequency", self._reference_frequency)
         for attr_name in ("orbit_x", "orbit_y",
                           "beta_x", "beta_y", "alpha_x", "alpha_y", "nu_x", "nu_y",
                           "bpm_x_attr", "bpm_y_attr", "hor", "vert"):
             self.set_change_event(attr_name, True, False)
         self.set_state(DevState.ON)
+
+    def _sync_write_value(self, attr_name: str, value) -> None:
+        sync_write_value(self, attr_name, value)
+
+    def _initial_reference_frequency(self) -> float:
+        """Return the average RF cavity frequency in kHz from the current lattice."""
+        if not self._rf_cavity_uuids:
+            return 0.0
+        try:
+            raw = get_controller().mexec._proxy.sync_trigger_read(
+                self._rf_cavity_uuids,
+                ["frequency"] * len(self._rf_cavity_uuids),
+            )
+            values = [
+                float(payload) / 1000.0
+                for _, _, payload in raw
+                if payload is not None
+            ]
+            if values:
+                return sum(values) / len(values)
+        except Exception as exc:
+            logger.debug("RingSimulatorDevice: could not initialise RF frequency: %s", exc)
+        return 0.0
+
+    @command
+    def RefreshFromCache(self) -> None:
+        """Refresh RF aggregate read/write cache from the current lattice."""
+        self._reference_frequency = self._initial_reference_frequency()
+        self._sync_write_value("reference_frequency", self._reference_frequency)
+        logger.info(
+            "%s: RefreshFromCache done — reference_frequency=%.6f kHz",
+            self.get_name(),
+            self._reference_frequency,
+        )
 
     # Orbit
     @attribute(dtype=DevDouble, dformat=AttrDataFormat.SPECTRUM, max_dim_x=MAX_ELEMS)
@@ -296,6 +332,7 @@ class RingSimulatorDevice(Device, AsyncMixin):
         try:
             self._start_async()
             get_controller().reset()
+            self.RefreshFromCache()
             self.set_state(DevState.ON)
             logger.warning("RingSimulatorDevice.Reset: complete — recalculation queued")
         except Exception as exc:
@@ -311,6 +348,7 @@ class RingSimulatorDevice(Device, AsyncMixin):
         try:
             self._start_async()
             get_controller().reinit()
+            self.RefreshFromCache()
             self.set_state(DevState.ON)
             logger.warning("RingSimulatorDevice.Reinit: complete — nominal state restored")
         except Exception as exc:

--- a/src/dt4acc/custom_tango/ioc/devices/write_value_sync.py
+++ b/src/dt4acc/custom_tango/ioc/devices/write_value_sync.py
@@ -1,0 +1,20 @@
+"""Helpers for synchronising Tango write-side setpoints."""
+
+from tango.server import Device
+
+from dt4acc.core.utils.logger import get_logger
+
+logger = get_logger()
+
+
+def sync_write_value(device: Device, attr_name: str, value) -> None:
+    """Mirror an internally refreshed value into Tango's write cache."""
+    try:
+        device.get_device_attr().get_w_attr_by_name(attr_name).set_write_value(value)
+    except Exception as exc:
+        logger.debug(
+            "%s: could not sync write value for %s: %s",
+            device.get_name(),
+            attr_name,
+            exc,
+        )

--- a/src/dt4acc/custom_tango/ioc/single_server.py
+++ b/src/dt4acc/custom_tango/ioc/single_server.py
@@ -218,7 +218,6 @@ def get_nominal_values(uuid: str) -> dict:
 
 def refresh_one_from_lattice(uuid: str, prop_spec=None) -> None:
     """Refresh one element in this Tango server process cache from the lattice."""
-    global _initial_values_cache, _initial_strength_cache, _nominal_cache
     if _sync_proxy is None:
         return
     props = _props_for_uuid(uuid, prop_spec)

--- a/src/dt4acc/custom_tango/ioc/single_server.py
+++ b/src/dt4acc/custom_tango/ioc/single_server.py
@@ -25,7 +25,12 @@ from typing import Sequence
 from dt4acc_lib.interfaces.backend.calculation_states import CalculationStates
 from dt4acc_lib.model.utils.tango_resource_locator import TangoResourceLocator
 
-from dt4acc.config.data.querries import get_unique_power_converters, get_magnets_per_power_converters
+from dt4acc.config.data.querries import (
+    get_magnets,
+    get_unique_power_converters,
+    get_unique_power_converters_type_specified,
+    get_magnets_per_power_converters,
+)
 from dt4acc.core.bl.controller import Controller
 from dt4acc.custom_tango.views.view import TangoView
 from dt4acc.custom_tango.ioc.mexec_server_for_physics_engine import _connect_to_mexec_service
@@ -121,15 +126,52 @@ class AsyncMexecAdapter:
         return r
 
 
-# Process-global cache: uuid → {property: value}
+# Process-global cache: uuid -> {property: value}
 # Populated by _preload_initial_values() before init_device() runs.
-# Re-populated by refresh_cache_from_lattice() after reset.
-_initial_strength_cache: dict = {}  # uuid → float (main_strength)
-_nominal_cache: dict = {}           # uuid → {"main_strength": f, "x_kick": f, "y_kick": f}
-_my_magnet_uuids: list = []         # UUIDs of magnets in this server process
-_uuid_to_prop: dict = {}            # uuid → lattice_property (e.g. "main_strength", "B2", "A2")
+# Re-populated by refresh_cache_from_lattice() after reset/reinit.
+_initial_values_cache: dict = {}
+_initial_strength_cache: dict = {}  # Legacy uuid -> float main_strength fallback.
+_nominal_cache: dict = {}
+_my_magnet_uuids: list = []         # UUIDs of magnets in this server process.
+_uuid_to_prop: dict = {}            # uuid -> lattice_property or tuple of properties.
 _sync_proxy = None                  # MexecService proxy for live reads
 _device_view = False                # True only for device-view facilities (e.g. MAX IV)
+
+
+def _default_lattice_values() -> dict:
+    return {
+        "main_strength": 0.0,
+        "x_kick": 0.0,
+        "y_kick": 0.0,
+        "frequency": 0.0,
+        "voltage": 0.0,
+    }
+
+
+def _as_props(prop_spec) -> tuple:
+    if prop_spec is None:
+        return ("main_strength",)
+    if isinstance(prop_spec, str):
+        return (prop_spec,)
+    return tuple(prop_spec)
+
+
+def _rf_cavity_uuids() -> set:
+    return {
+        m.get("uuid")
+        for m in get_magnets()
+        if m.get("type") == "RFCavity" and m.get("uuid")
+    }
+
+
+def _props_for_uuid(uuid: str, prop_spec=None) -> tuple:
+    if prop_spec is not None:
+        return _as_props(prop_spec)
+    if uuid in _uuid_to_prop:
+        return _as_props(_uuid_to_prop[uuid])
+    if uuid in _rf_cavity_uuids():
+        return ("frequency", "voltage")
+    return ("main_strength",)
 
 
 def enable_device_view_readback() -> None:
@@ -160,33 +202,61 @@ def get_initial_strength(uuid: str) -> float:
     return _initial_strength_cache.get(uuid, 0.0)
 
 
+def get_initial_values(uuid: str) -> dict:
+    """Called by device init_device() to get cached initial lattice values."""
+    vals = _default_lattice_values()
+    vals.update(_initial_values_cache.get(uuid, {}))
+    return vals
+
+
 def get_nominal_values(uuid: str) -> dict:
-    """Called by MagnetDevice.RefreshFromCache() after reset."""
-    return _nominal_cache.get(uuid, {"main_strength": 0.0, "x_kick": 0.0, "y_kick": 0.0})
+    """Called by device RefreshFromCache() after reset/reinit."""
+    vals = _default_lattice_values()
+    vals.update(_nominal_cache.get(uuid, {}))
+    return vals
+
+
+def refresh_one_from_lattice(uuid: str, prop_spec=None) -> None:
+    """Refresh one element in this Tango server process cache from the lattice."""
+    global _initial_values_cache, _initial_strength_cache, _nominal_cache
+    if _sync_proxy is None:
+        return
+    props = _props_for_uuid(uuid, prop_spec)
+    try:
+        raw = _sync_proxy.sync_trigger_read([uuid] * len(props), list(props))
+    except Exception as exc:
+        logger.debug("refresh_one_from_lattice: %s failed: %s", uuid, exc)
+        return
+
+    values = _nominal_cache.setdefault(uuid, {})
+    for rcmd_id, rcmd_prop, payload in raw:
+        if rcmd_id != uuid or payload is None:
+            continue
+        try:
+            values[rcmd_prop] = float(payload)
+        except (TypeError, ValueError):
+            pass
+    _initial_values_cache[uuid] = dict(values)
+    _initial_strength_cache[uuid] = values.get("main_strength", 0.0)
 
 
 def refresh_cache_from_lattice(sync_proxy, magnet_uuids: list, uuid_to_prop: dict = None) -> None:
     """
     Bulk-read current lattice values for all magnets after reset.
     Uses per-uuid lattice_property — same approach as _preload_initial_values.
-    Correctors (B2/A2) always reset to 0.0, not read from lattice.
     """
-    global _initial_strength_cache, _nominal_cache
+    global _initial_values_cache, _initial_strength_cache, _nominal_cache
     if not magnet_uuids:
         return
 
-    _TYPE_TO_PROP = {"QuadrupoleCorrector": "B2", "SkewQuadrupoleCorrector": "A2"}
     prop_groups = defaultdict(list)
     for uuid in magnet_uuids:
-        prop = (uuid_to_prop or {}).get(uuid, "main_strength")
-        if prop in ("B2", "A2"):
-            continue  # correctors reset to 0.0
-        prop_groups[prop].append(uuid)
+        for prop in _props_for_uuid(uuid, (uuid_to_prop or {}).get(uuid, None)):
+            prop_groups[prop].append(uuid)
 
     logger.warning("Refreshing nominal cache for %d magnets...",
                    sum(len(v) for v in prop_groups.values()))
-    new_cache = {uuid: {(uuid_to_prop or {}).get(uuid, "main_strength"): 0.0}
-                 for uuid in magnet_uuids}
+    new_cache = {uuid: {} for uuid in magnet_uuids}
 
     for prop, ids in prop_groups.items():
         try:
@@ -202,6 +272,7 @@ def refresh_cache_from_lattice(sync_proxy, magnet_uuids: list, uuid_to_prop: dic
             logger.warning("refresh_cache_from_lattice: %s failed: %s", prop, exc)
 
     _nominal_cache = new_cache
+    _initial_values_cache = dict(new_cache)
     _initial_strength_cache = {
         uuid: v.get("main_strength", 0.0) for uuid, v in new_cache.items()
     }
@@ -214,18 +285,17 @@ def _preload_initial_values(sync_proxy, magnet_uuids: list, uuid_to_prop: dict =
     Uses per-uuid lattice_property to avoid sending "main_strength"
     to octupole/corrector elements that don't support it.
     """
-    global _initial_strength_cache # noqa: F824
+    global _initial_values_cache, _initial_strength_cache, _nominal_cache
     if not magnet_uuids:
         return
 
-    # Group uuids by their lattice_property — one batch per property
+    new_cache = {uuid: {} for uuid in magnet_uuids}
+
+    # Group uuids by their lattice properties — one batch per property.
     prop_groups = defaultdict(list)
     for uuid in magnet_uuids:
-        prop = (uuid_to_prop or {}).get(uuid, "main_strength")
-        # Skip corrector properties (B2/A2) — they start at 0.0 always
-        if prop in ("B2", "A2"):
-            continue
-        prop_groups[prop].append(uuid)
+        for prop in _props_for_uuid(uuid, (uuid_to_prop or {}).get(uuid, None)):
+            prop_groups[prop].append(uuid)
 
     logger.warning("Pre-loading initial values for %d magnets...",
                    sum(len(v) for v in prop_groups.values()))
@@ -236,13 +306,20 @@ def _preload_initial_values(sync_proxy, magnet_uuids: list, uuid_to_prop: dict =
             for rcmd_id, rcmd_prop, payload in raw:
                 if payload is not None:
                     try:
-                        _initial_strength_cache[rcmd_id] = float(payload)
+                        new_cache.setdefault(rcmd_id, {})[rcmd_prop] = float(payload)
                     except (TypeError, ValueError):
                         pass
         except Exception as exc:
             logger.warning("Bulk pre-load failed for %s: %s — devices will start at 0.0",
                            prop, exc)
-    logger.warning("Pre-loaded %d initial values.", len(_initial_strength_cache))
+
+    _initial_values_cache = new_cache
+    _nominal_cache = dict(new_cache)
+    _initial_strength_cache = {
+        uuid: vals.get("main_strength", 0.0)
+        for uuid, vals in new_cache.items()
+    }
+    logger.warning("Pre-loaded %d initial value sets.", len(_initial_values_cache))
 
 def _inject_controller(prefix: str) -> None:
     """
@@ -296,13 +373,20 @@ def main_loop(server_name: str, instance_name: str, event=None):
         my_uuids = []
         uuid_to_prop = {}
         _SUBTYPE_TO_PROP = {
-            "Quad": "main_strength", "Sext": "main_strength", "SkewSext": "main_strength",
+            "Quad": ("B2", "main_strength"),
+            "Sext": ("B3", "main_strength"),
+            "SkewSext": ("B3", "main_strength"),
             "Oct": "B4",
         }
         _TYPE_TO_PROP = {
             "QuadrupoleCorrector": "B2", "SkewQuadrupoleCorrector": "A2",
+            "RFCavity": ("frequency", "voltage"),
         }
-        for pc_name in get_unique_power_converters():
+        pc_names = (
+            get_unique_power_converters()
+            + get_unique_power_converters_type_specified(["RFCavity"])
+        )
+        for pc_name in pc_names:
             for m in get_magnets_per_power_converters(pc_name):
                 magnet_name = m["name"]
                 try:
@@ -315,7 +399,10 @@ def main_loop(server_name: str, instance_name: str, event=None):
                         my_uuids.append(uuid)
                         mtype = m.get("type", "")
                         subtype = m.get("subtype", "")
-                        prop = _TYPE_TO_PROP.get(mtype) or _SUBTYPE_TO_PROP.get(subtype, "main_strength")
+                        if mtype == "Steerer":
+                            prop = "y_kick" if subtype == "V" else "x_kick"
+                        else:
+                            prop = _TYPE_TO_PROP.get(mtype) or _SUBTYPE_TO_PROP.get(subtype, "main_strength")
                         uuid_to_prop[uuid] = prop
 
         global _my_magnet_uuids, _uuid_to_prop

--- a/src/dt4acc/custom_tango/ioc/tango_controller.py
+++ b/src/dt4acc/custom_tango/ioc/tango_controller.py
@@ -191,16 +191,29 @@ class TangoController(ControllerInterface):
 
             from tango import Database, DeviceProxy
             db = Database()
-            dev_list = db.get_device_exported_for_class("MagnetDevice")
             count = 0
-            for dev_name in dev_list.value_string:
+            class_names = (
+                "MultipoleDevice",
+                "HorizontalSteererDevice",
+                "VerticalSteererDevice",
+                "SkewQuadDevice",
+                "CavityDevice",
+                "CavityPowerConverterDevice",
+            )
+            for class_name in class_names:
                 try:
-                    dp = DeviceProxy(str(dev_name))
-                    dp.set_timeout_millis(1000)
-                    dp.command_inout("RefreshFromCache")
-                    count += 1
+                    dev_list = db.get_device_exported_for_class(class_name)
                 except Exception as exc:
-                    logger.debug("RefreshFromCache failed for %s: %s", dev_name, exc)
+                    logger.debug("Could not list exported %s devices: %s", class_name, exc)
+                    continue
+                for dev_name in dev_list.value_string:
+                    try:
+                        dp = DeviceProxy(str(dev_name))
+                        dp.set_timeout_millis(1000)
+                        dp.command_inout("RefreshFromCache")
+                        count += 1
+                    except Exception as exc:
+                        logger.debug("RefreshFromCache failed for %s: %s", dev_name, exc)
             logger.warning("TangoController.reset: RefreshFromCache sent to %d magnets", count)
         except Exception as exc:
             logger.warning("TangoController.reset: could not refresh magnets: %s", exc)


### PR DESCRIPTION
Synchronize model-backed write values with `WAttribute.set_write_value()` during startup and refresh paths. Cover RF cavities, global reference frequency, and RF power converter refresh without triggering backend writes.